### PR TITLE
Add universal config.xml transformation.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@
     <platform name="android">
 
         <!-- requires Cordova-2.8.0 -->
-        <config-file target="res/xml/config.xml" parent="/widget">
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="NfcPlugin">
                 <param name="android-package" value="com.chariotsolutions.nfc.plugin.NfcPlugin"/>
                 <param name="onload" value="true" />                


### PR DESCRIPTION
For old Cordova versions the root tag of the config.xml is cordova. This change applies a universal transformation similar to the way Core Cordova plugins do.
